### PR TITLE
Added `--input-file` option

### DIFF
--- a/fairtally/cli.py
+++ b/fairtally/cli.py
@@ -1,6 +1,5 @@
 import io
 import json
-from pathlib import Path
 import click
 from howfairis import Checker
 from howfairis import Compliance
@@ -8,6 +7,7 @@ from howfairis import Repo
 from tqdm import tqdm
 from fairtally.get_badge_color import get_badge_color
 from fairtally.redirect_stdout_stderr import RedirectStdStreams
+from fairtally.utils import merge_urls, write_as_json, write_as_html
 
 
 @click.command()
@@ -22,20 +22,6 @@ from fairtally.redirect_stdout_stderr import RedirectStdStreams
               help="Check URLs in file. One URL per line. Use `-` to read from standard input.",
               default=None, type=click.File('r'))
 def cli(urls=None, output_file_html=None, output_file_json=None, input_file=None):
-
-    def write_as_json():
-        with output_file_json:
-            json.dump(results, output_file_json, sort_keys=True)
-
-    def write_as_html():
-        parent = Path(__file__).parent
-        template_file = parent / "data" / "index.html.template"
-        with open(template_file) as f:
-            template_str = f.read()
-        report = template_str.replace("{{python inserts the data here}}", json.dumps(results))
-        with output_file_html:
-            output_file_html.write(report)
-
     all_urls = merge_urls(urls, input_file)
 
     if len(all_urls) == 0:
@@ -70,20 +56,10 @@ def cli(urls=None, output_file_html=None, output_file_json=None, input_file=None
         print(json.dumps(results))
 
     if output_file_json is not None:
-        write_as_json()
+        write_as_json(results, output_file_json)
 
     if output_file_html is not None:
-        write_as_html()
-
-
-def merge_urls(urls, input_file):
-    all_urls = list(urls)
-    if input_file is not None:
-        for line in input_file:
-            url = line.strip()
-            if url:
-                all_urls.append(url)
-    return all_urls
+        write_as_html(results, output_file_html)
 
 
 if __name__ == "__main__":

--- a/fairtally/cli.py
+++ b/fairtally/cli.py
@@ -7,7 +7,9 @@ from howfairis import Repo
 from tqdm import tqdm
 from fairtally.get_badge_color import get_badge_color
 from fairtally.redirect_stdout_stderr import RedirectStdStreams
-from fairtally.utils import merge_urls, write_as_json, write_as_html
+from fairtally.utils import merge_urls
+from fairtally.utils import write_as_html
+from fairtally.utils import write_as_json
 
 
 @click.command()

--- a/fairtally/utils.py
+++ b/fairtally/utils.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
-from typing import TextIO, List, Set
+from typing import List
+from typing import Set
+from typing import TextIO
 
 
 def merge_urls(urls: Set[str], input_file: TextIO) -> List[str]:

--- a/fairtally/utils.py
+++ b/fairtally/utils.py
@@ -1,9 +1,9 @@
 import json
 from pathlib import Path
-from typing import TextIO, List
+from typing import TextIO, List, Set
 
 
-def merge_urls(urls: List[str], input_file: TextIO):
+def merge_urls(urls: Set[str], input_file: TextIO) -> List[str]:
     all_urls = list(urls)
     if input_file is not None:
         for line in input_file:
@@ -13,7 +13,7 @@ def merge_urls(urls: List[str], input_file: TextIO):
     return all_urls
 
 
-def write_as_html(results, output_file_html):
+def write_as_html(results, output_file_html: TextIO):
     parent = Path(__file__).parent
     template_file = parent / "data" / "index.html.template"
     with open(template_file) as f:
@@ -23,6 +23,6 @@ def write_as_html(results, output_file_html):
         output_file_html.write(report)
 
 
-def write_as_json(results, output_file_json):
+def write_as_json(results, output_file_json: TextIO):
     with output_file_json:
         json.dump(results, output_file_json, sort_keys=True)

--- a/fairtally/utils.py
+++ b/fairtally/utils.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+from typing import TextIO, List
+
+
+def merge_urls(urls: List[str], input_file: TextIO):
+    all_urls = list(urls)
+    if input_file is not None:
+        for line in input_file:
+            url = line.strip()
+            if url:
+                all_urls.append(url)
+    return all_urls
+
+
+def write_as_html(results, output_file_html):
+    parent = Path(__file__).parent
+    template_file = parent / "data" / "index.html.template"
+    with open(template_file) as f:
+        template_str = f.read()
+    report = template_str.replace("{{python inserts the data here}}", json.dumps(results))
+    with output_file_html:
+        output_file_html.write(report)
+
+
+def write_as_json(results, output_file_json):
+    with output_file_json:
+        json.dump(results, output_file_json, sort_keys=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,13 +34,35 @@ def mocked_internet():
 def invoke_cli(mocked_internet):
     runner = CliRunner()
 
-    def _invoker(args):
+    def _invoker(args, **kwargs):
         with mocked_internet:
-            return runner.invoke(cli, args, catch_exceptions=False)
+            return runner.invoke(cli, args, catch_exceptions=False, **kwargs)
 
     return _invoker
 
 
+def test_nourl(invoke_cli):
+    result = invoke_cli("")
+    assert "No URLs provided, aborting." in result.output
+
+
 def test_singleurl_nooptions(invoke_cli):
     result = invoke_cli("https://github.com/fair-software/repo1")
+    assert "fairtally progress" in result.output
+
+
+def test_input_from_file(invoke_cli, tmp_path):
+    my_input_file = tmp_path / 'urls.txt'
+    my_input_file.write_text("https://github.com/fair-software/repo1\n")
+
+    result = invoke_cli(["--input-file", str(my_input_file)])
+
+    assert "fairtally progress" in result.output
+
+
+def test_input_from_stdin(invoke_cli):
+    stdin = "https://github.com/fair-software/repo1\n"
+
+    result = invoke_cli(["--input-file", "-"], input=stdin)
+
     assert "fairtally progress" in result.output


### PR DESCRIPTION
Fixes #27

For review following commands should all work

```
fairtally https://github.com/fair-software/fairtally
echo 'https://github.com/fair-software/fairtally' > u.txt
cat u.txt | fairtally --input-file -
fairtally --input-file u.txt
```
