### PR TITLE
40-show all rows by default

### DIFF
--- a/fairtally/data/index.html.template
+++ b/fairtally/data/index.html.template
@@ -15,7 +15,7 @@
 <body>
   <div id="q-app" style="min-height: 100vh;">
     <div class="q-pa-md">
-      <q-table title="Fairtally results" :rows="rows" :columns="columns" row-key="url" >
+      <q-table title="Fairtally results" :rows="rows" :columns="columns" row-key="url" :pagination.sync="pagination" >
 
         <template v-slot:header="props">
           <q-tr :props="props">
@@ -151,7 +151,10 @@
       setup() {
         return {
           columns,
-          rows
+          rows,
+          pagination: {
+            rowsPerPage: 0
+          },
         }
       }
     })


### PR DESCRIPTION
Shows all the records by default.
Refs: #40

To test:
1. Add some urls to a txt file
  Example file content:
  ```
  https://github.com/SCM-NV/qmflows
  https://github.com/3D-e-Chem/sygma
  https://github.com/3D-e-Chem/3D-e-Chem-VM
  https://github.com/NLeSC/ahn-pointcloud-viewer-ws
  https://github.com/NLeSC/ahn-pointcloud-viewer
  https://github.com/nlesc-ave/ave-rest-service
  ```
2. Run fairtally 
    ```fairtally --html report.html --input-file rsd-urls.txt```
3. Open report.html using your web-browser and check if you"records per page" is set to "All"
4. Compare the report.html with the screenshot below
![image](https://user-images.githubusercontent.com/144492/110117890-d28fe700-7db9-11eb-8ba5-39bf09ecaa83.png)
