### PR TITLE
turn url text into link

### DIFF
--- a/fairtally/data/index.html.template
+++ b/fairtally/data/index.html.template
@@ -36,7 +36,7 @@
               <q-btn size="sm" color="accent" round dense @click="props.expand = !props.expand" :icon="props.expand ? 'remove' : 'add'"></q-btn>
             </q-td>
             <q-td>
-              <span>{{ props.row.url }}</span>
+              <a :href="props.row.url" target="_blank">{{ props.row.url }}</a>
             </q-td>
             <q-td>
               <compliance :status="props.row.repository" />


### PR DESCRIPTION
Converts the text in url column in to a link.

To test:
1. Generate the report
1. Test the links to see if they are opened in a new tab