### PR TITLE
changed version number setup in setup files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ current_version = 0.0.0
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
 [bumpversion:file:CITATION.cff]
 search = version: "{current_version}"
 replace = version: "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import os
-from fairtally.__version__ import __version__
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -14,7 +13,7 @@ setup(
     entry_points={
         "console_scripts": ["fairtally=fairtally.cli:cli"],
     },
-    version=__version__,
+    version="0.0.0",
     description="Make a report based on howfairis results",
     long_description=readme + "\n\n",
     author="FAIR Software",


### PR DESCRIPTION
The existing version number setup was expected not to work for a pypi release so we changed to the same setup as in howfairis