### PR TITLE
lingering progressbar text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ docs/apidocs
 
 # Mac
 .DS_Store
+
+# fairtally default output file with results
+/tally.html
+
+# virtual environment
+/venv3

--- a/fairtally/cli.py
+++ b/fairtally/cli.py
@@ -35,6 +35,7 @@ def cli(urls, input_file, output_format, output_filename):
     url_progressbar = tqdm(all_urls, bar_format="fairtally progress: |{bar}| {n_fmt}/{total_fmt}", ncols=70, position=0)
     current_value = tqdm(total=0, bar_format="{desc}", position=1)
     results = [check_url(url, current_value) for url in url_progressbar]
+    current_value.close()
 
     if output_filename == DEFAULT_OUTPUT_FILENAME and output_format == "json":
         output_filename = "tally.json"


### PR DESCRIPTION
Refs #80

output should now look like this (no lingering text)

```shell
┌─ 07:53:58 /tmp/demo.b347rJ (venv3) 
└─ $ fairtally `cat rsd-urls.txt | tail -n 2`
fairtally progress: |████████████████████████████████████████████| 2/2
currently checking https://github.com/puregome/notebooks    
┌─ 07:54:07 /tmp/demo.b347rJ (venv3)                                  <-- no lingering text here
└─ $ 
```