### PR TITLE
Clean up coverage writing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+data_file = coverage/.coverage
+branch = true
+
+[paths]
+source = fairtally/
+
+[html]
+directory = coverage/htmlcov/
+
+[xml]
+output = coverage/coverage.xml
+
+[report]
+omit =
+    venv*
+    tests/*

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -1,0 +1,1 @@
+The coverage reports will be written in this directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ description-file = README.rst
 
 [tool:pytest]
 testpaths = tests
-addopts = --cov --cov-report xml --cov-report term --cov-report html
 
 [tool:isort]
 lines_after_imports = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,15 +22,12 @@ build-dir = docs/_build
 all_files = 1
 builder = html
 
-[coverage:run]
-branch = True
-source = fairtally
-
 [metadata]
 description-file = README.rst
 
 [tool:pytest]
 testpaths = tests
+addopts = --cov --cov-config=.coveragerc --cov-report html --cov-report term --cov-report xml
 
 [tool:isort]
 lines_after_imports = 2


### PR DESCRIPTION
coverage was written into various places, this PR cleans that up. Everything is now under /coverage, like so:

```
coverage/
├── .coverage
├── coverage.xml
├── htmlcov
│   ├── coverage_html.js
│   ├── fairtally_check_py.html
│   ├── fairtally_cli_py.html
│   ├── fairtally___init___py.html
│   ├── fairtally_redirect_stdout_stderr_py.html
│   ├── fairtally_utils_py.html
│   ├── fairtally___version___py.html
│   ├── favicon_32.png
│   ├── index.html
│   ├── jquery.ba-throttle-debounce.min.js
│   ├── jquery.hotkeys.js
│   ├── jquery.isonscreen.js
│   ├── jquery.min.js
│   ├── jquery.tablesorter.min.js
│   ├── keybd_closed.png
│   ├── keybd_open.png
│   ├── status.json
│   └── style.css
└── README.md
```
